### PR TITLE
BugFix: Close source file

### DIFF
--- a/ResizeImageModule.psm1
+++ b/ResizeImageModule.psm1
@@ -73,6 +73,9 @@
 
     # Save the image
     $destImage.Save($OutputFile)
+
+    # Close source file
+    $image.Dispose()
 }
 
 function Resize-ImagesInFolder {


### PR DESCRIPTION
Used the module on a temporary file. Could not delete the source file after resizing.

Reproduce:
- get a new image to anywhere
- run Resize-Image on that file
- keep PowerShell open
- try to delete the source file

Expected Result:
- source file is deleted

Actual Result:
- IO-Error, file is still open

Solution:
- close the resource when done
- see https://learn.microsoft.com/en-us/dotnet/api/system.drawing.image?view=netframework-4.8.1
- there is no Close(), but there is Dispose()